### PR TITLE
Play a sound when retrieving experience points from the tome

### DIFF
--- a/src/main/java/com/hangbunny/item/TomeOfExperience.java
+++ b/src/main/java/com/hangbunny/item/TomeOfExperience.java
@@ -8,6 +8,8 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
+import net.minecraft.sound.SoundEvents;
+import net.minecraft.sound.SoundCategory;
 import net.minecraft.text.Text;
 import net.minecraft.util.Hand;
 import net.minecraft.util.TypedActionResult;
@@ -90,6 +92,11 @@ public class TomeOfExperience extends Item {
                 stack.setNbt(tags);
 
                 user.addExperience(pointsToTransfer);
+
+                // Play a sound when getting experience points
+                float volumeMultiplier = 0.1F;
+                float pitchMultiplier = (world.random.nextFloat() - world.random.nextFloat()) * 0.35F + 0.9F;
+                world.playSound(null, user.getBlockPos(), SoundEvents.ENTITY_EXPERIENCE_ORB_PICKUP, SoundCategory.PLAYERS, volumeMultiplier, pitchMultiplier);
             }
         } else {
             // On the client side


### PR DESCRIPTION
There's an attempt to emulate the sounds made in vanilla Minecraft when picking up XP orbs by lowering the volume and varying the pitch of the sound effect.