### PR TITLE
Add efficiency losses when storing experience points in a tome

### DIFF
--- a/src/main/java/com/hangbunny/config/TomesOfExperienceConfig.java
+++ b/src/main/java/com/hangbunny/config/TomesOfExperienceConfig.java
@@ -10,4 +10,6 @@ public class TomesOfExperienceConfig implements ConfigData {
 
     @Comment("The maximum amount of experience points a tome can hold")
     public int experience_points_capacity = 1395;
+    @Comment("The percentage of experience points the tome will convert to store")
+    public float experience_points_efficiency = 0.98F;
 }

--- a/src/main/java/com/hangbunny/item/TomeOfExperience.java
+++ b/src/main/java/com/hangbunny/item/TomeOfExperience.java
@@ -2,6 +2,7 @@ package com.hangbunny.item;
 
 import java.util.List;
 
+import com.hangbunny.TomesOfExperience;
 import com.hangbunny.experience.ExperienceUtils;
 import net.minecraft.client.item.TooltipContext;
 import net.minecraft.entity.player.PlayerEntity;
@@ -69,7 +70,11 @@ public class TomeOfExperience extends Item {
                 user.addExperienceLevels(-1);
 
                 int pointsTranferred = pointsPlayer - ExperienceUtils.getExperiencePoints(user);
-                pointsTome += pointsTranferred;
+
+                float efficiency = TomesOfExperience.CONFIG.experience_points_efficiency;
+                // Apply an efficiency loss when storing experience points
+                // Using 'floor' to be biased towards losing experience points in the transfer.
+                pointsTome += (int) Math.floor(pointsTranferred * efficiency);
                 tags.putInt("experience", pointsTome);
                 stack.setNbt(tags);
 

--- a/src/main/resources/assets/tomes_of_experience/lang/en_us.json
+++ b/src/main/resources/assets/tomes_of_experience/lang/en_us.json
@@ -3,5 +3,6 @@
     "item.tomes_of_experience.tome_of_experience.tooltip.empty": "Empty",
 
     "text.autoconfig.tomes_of_experience.title": "Tomes Of Experience Config",
-    "text.autoconfig.tomes_of_experience.option.experience_points_capacity": "Max Experience Points in Tome"
+    "text.autoconfig.tomes_of_experience.option.experience_points_capacity": "Max Experience Points in Tome",
+    "text.autoconfig.tomes_of_experience.option.experience_points_efficiency": "Experience Point Storage Efficiency"
 }


### PR DESCRIPTION
The efficiency losses are biased towards always losing at least one experience points in a transfer.