### PR TITLE
Decrease versions of dependencies

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.parallel=true
 # check these on https://fabricmc.net/develop
 minecraft_version=1.20.1
 yarn_mappings=1.20.1+build.10
-loader_version=0.15.7
+loader_version=0.14.25
 
 # Mod Properties
 mod_version=0.0.2
@@ -14,6 +14,6 @@ maven_group=com.hangbunny
 archives_base_name=tomes-of-experience
 
 # Dependencies
-fabric_version=0.92.0+1.20.1
-cloth_config_version=11.1.118
+fabric_version=0.91.0+1.20.1
+cloth_config_version=11.1.106
 mod_menu_version=7.2.2


### PR DESCRIPTION
Newer dependencies weren't actually needed and this allows compatibility with some popular modpacks.