### PR TITLE
Reduce rolls for common tomes

### DIFF
--- a/src/main/java/com/hangbunny/config/LootTableConfig.java
+++ b/src/main/java/com/hangbunny/config/LootTableConfig.java
@@ -90,7 +90,7 @@ public class LootTableConfig {
             if (source.isBuiltin()
                     && lootContainers.contains(id)) {
                 LootPool.Builder poolBuilder = LootPool.builder()
-                        .rolls(ConstantLootNumberProvider.create(2))
+                        .rolls(ConstantLootNumberProvider.create(1))
                         .conditionally(RandomChanceLootCondition.builder(lootChanceCommon))
                         .with(ItemEntry.builder(TomesOfExperience.TomeOfMinorExperience)
                             .weight(6)


### PR DESCRIPTION
Doing two rolls made it too common for two tomes to appear in chests.