### PR TITLE
Update recipe datapack for 1.21

### DIFF
--- a/src/main/resources/data/tomes_of_experience/recipe/tome_of_experience.json
+++ b/src/main/resources/data/tomes_of_experience/recipe/tome_of_experience.json
@@ -20,6 +20,6 @@
       }
     },
     "result": {
-      "item": "tomes_of_experience:tome_of_experience"
+      "id": "tomes_of_experience:tome_of_experience"
     }
   }

--- a/src/main/resources/data/tomes_of_experience/recipe/tome_of_greater_experience.json
+++ b/src/main/resources/data/tomes_of_experience/recipe/tome_of_greater_experience.json
@@ -20,6 +20,6 @@
       }
     },
     "result": {
-      "item": "tomes_of_experience:tome_of_greater_experience"
+      "id": "tomes_of_experience:tome_of_greater_experience"
     }
   }

--- a/src/main/resources/data/tomes_of_experience/recipe/tome_of_lesser_experience.json
+++ b/src/main/resources/data/tomes_of_experience/recipe/tome_of_lesser_experience.json
@@ -14,6 +14,6 @@
       }
     },
     "result": {
-      "item": "tomes_of_experience:tome_of_lesser_experience"
+      "id": "tomes_of_experience:tome_of_lesser_experience"
     }
   }

--- a/src/main/resources/data/tomes_of_experience/recipe/tome_of_major_experience.json
+++ b/src/main/resources/data/tomes_of_experience/recipe/tome_of_major_experience.json
@@ -10,6 +10,6 @@
     "item": "minecraft:netherite_ingot"
   },
   "result": {
-    "item": "tomes_of_experience:tome_of_major_experience"
+    "id": "tomes_of_experience:tome_of_major_experience"
   }
 }

--- a/src/main/resources/data/tomes_of_experience/recipe/tome_of_minor_experience.json
+++ b/src/main/resources/data/tomes_of_experience/recipe/tome_of_minor_experience.json
@@ -14,6 +14,6 @@
       }
     },
     "result": {
-      "item": "tomes_of_experience:tome_of_minor_experience"
+      "id": "tomes_of_experience:tome_of_minor_experience"
     }
   }

--- a/src/main/resources/data/tomes_of_experience/recipe/tome_of_superior_experience.json
+++ b/src/main/resources/data/tomes_of_experience/recipe/tome_of_superior_experience.json
@@ -20,6 +20,6 @@
       }
     },
     "result": {
-      "item": "tomes_of_experience:tome_of_superior_experience"
+      "id": "tomes_of_experience:tome_of_superior_experience"
     }
   }


### PR DESCRIPTION
The directory name for recipe datapacks has changed from ‘recipes’ to ‘recipe’. The ‘result’ key in a recipe is now expected to return an object with an ‘id’ key, instead of ‘item’.

fixes #28 