### PR TITLE
Fix experience point transfers

### DIFF
--- a/src/main/java/com/hangbunny/item/BaseTomeOfExperience.java
+++ b/src/main/java/com/hangbunny/item/BaseTomeOfExperience.java
@@ -232,13 +232,15 @@ public abstract class BaseTomeOfExperience extends Item {
                 }
             }
         } else {
+            int pointsToNextLevel = user.getNextLevelExperience();
+            int pointsCurrentLevel = (int) Math.ceil(user.experienceProgress * (float)pointsToNextLevel);
             // On the client side
             // Don't swing the player's arm when:
             //   The player has no experience points
             //   The tome is either empty or full
             //   No experience points would be transferred in either direction
             //   The player doesn't have the minimum experience level required by the tome
-            boolean canReceivePoints = (pointsTome < this.getCapacity()) && (user.totalExperience > 0);
+            boolean canReceivePoints = (pointsTome < this.getCapacity()) && !(user.experienceLevel == 0 && pointsCurrentLevel == 0);
             boolean canProvidePoints = (pointsTome > 0);
             boolean playerHasPoints = (user.experienceLevel > 0) || (user.experienceProgress > 0);
 

--- a/src/main/java/com/hangbunny/item/TomeOfExperience.java
+++ b/src/main/java/com/hangbunny/item/TomeOfExperience.java
@@ -34,7 +34,13 @@ public class TomeOfExperience extends BaseTomeOfExperience {
         // Transfer all the points in the current level plus
         // a single point to go down to the previous level.
         int pointsToTransfer = pointsCurrentLevel + 1;
-        if (pointsToTransfer > user.totalExperience) { pointsToTransfer = user.totalExperience; }
+
+        // 'user.totalExperience' doesn't seem to report reliable values.
+        // Check that we're not transferring more points than the player has by
+        // checking both the level and the points in the current level.
+        if (user.experienceLevel == 0 && pointsToTransfer > pointsCurrentLevel) {
+            pointsToTransfer = pointsCurrentLevel;
+        }
 
         // Try to transfer the points to the tome and subtract the amount that
         // could be transferred from the player.

--- a/src/main/java/com/hangbunny/item/TomeOfGreaterExperience.java
+++ b/src/main/java/com/hangbunny/item/TomeOfGreaterExperience.java
@@ -34,7 +34,13 @@ public class TomeOfGreaterExperience extends BaseTomeOfExperience {
         // Transfer all the points in the current level plus
         // a single point to go down to the previous level.
         int pointsToTransfer = pointsCurrentLevel + 1;
-        if (pointsToTransfer > user.totalExperience) { pointsToTransfer = user.totalExperience; }
+
+        // 'user.totalExperience' doesn't seem to report reliable values.
+        // Check that we're not transferring more points than the player has by
+        // checking both the level and the points in the current level.
+        if (user.experienceLevel == 0 && pointsToTransfer > pointsCurrentLevel) {
+            pointsToTransfer = pointsCurrentLevel;
+        }
 
         // Try to transfer the points to the tome and subtract the amount that
         // could be transferred from the player.

--- a/src/main/java/com/hangbunny/item/TomeOfLesserExperience.java
+++ b/src/main/java/com/hangbunny/item/TomeOfLesserExperience.java
@@ -38,7 +38,13 @@ public class TomeOfLesserExperience extends BaseTomeOfExperience {
         int pointsToTransfer = pointsCurrentLevel > halfOfCurrentLevel
             ? halfOfCurrentLevel
             : pointsCurrentLevel + 1;
-        if (pointsToTransfer > user.totalExperience) { pointsToTransfer = user.totalExperience; }
+
+        // 'user.totalExperience' doesn't seem to report reliable values.
+        // Check that we're not transferring more points than the player has by
+        // checking both the level and the points in the current level.
+        if (user.experienceLevel == 0 && pointsToTransfer > pointsCurrentLevel) {
+            pointsToTransfer = pointsCurrentLevel;
+        }
         
         // Try to transfer the points to the tome and subtract the amount that
         // could be transferred from the player.
@@ -50,17 +56,16 @@ public class TomeOfLesserExperience extends BaseTomeOfExperience {
 
     @Override
     protected int transferToPlayer(ItemStack tomeItemStack, PlayerEntity user) {
-        int pointsTotal = user.totalExperience;
         int pointsToNextLevel = user.getNextLevelExperience();
         int pointsCurrentLevel = (int) Math.ceil(user.experienceProgress * (float)pointsToNextLevel);
-        int pointsNextLevel = pointsTotal - pointsCurrentLevel + pointsToNextLevel;
+        int pointsNextLevel = pointsToNextLevel - pointsCurrentLevel ;
 
         // Transfer half of the points that the current level could hold.
         // If the transfer would cause the player to level up, just transfer enough
         // points to go up to the next level.
         int halfOfCurrentLevel = (int) Math.ceil((float)pointsToNextLevel * 0.5f);
-        int pointsToTransfer = pointsTotal + halfOfCurrentLevel > pointsNextLevel
-            ? pointsNextLevel - pointsTotal + 1
+        int pointsToTransfer = halfOfCurrentLevel > pointsNextLevel
+            ? pointsNextLevel
             : halfOfCurrentLevel;
 
         // Try to get the points from the tome - or as many as it can provide - and 

--- a/src/main/java/com/hangbunny/item/TomeOfMajorExperience.java
+++ b/src/main/java/com/hangbunny/item/TomeOfMajorExperience.java
@@ -38,7 +38,13 @@ public class TomeOfMajorExperience extends BaseTomeOfExperience {
             // Transfer all the points in the current level plus
             // a single point to go down to the previous level.
             int pointsToTransfer = pointsCurrentLevel + 1;
-            if (pointsToTransfer > user.totalExperience) { pointsToTransfer = user.totalExperience; }
+
+            // 'user.totalExperience' doesn't seem to report reliable values.
+            // Check that we're not transferring more points than the player has by
+            // checking both the level and the points in the current level.
+            if (user.experienceLevel == 0 && pointsToTransfer > pointsCurrentLevel) {
+                pointsToTransfer = pointsCurrentLevel;
+            }
 
             // Try to transfer the points to the tome and subtract the amount that
             // could be transferred from the player.

--- a/src/main/java/com/hangbunny/item/TomeOfMinorExperience.java
+++ b/src/main/java/com/hangbunny/item/TomeOfMinorExperience.java
@@ -38,7 +38,13 @@ public class TomeOfMinorExperience extends BaseTomeOfExperience {
         int pointsToTransfer = pointsCurrentLevel > thirdOfCurrentLevel
             ? thirdOfCurrentLevel
             : pointsCurrentLevel + 1;
-        if (pointsToTransfer > user.totalExperience) { pointsToTransfer = user.totalExperience; }
+
+        // 'user.totalExperience' doesn't seem to report reliable values.
+        // Check that we're not transferring more points than the player has by
+        // checking both the level and the points in the current level.
+        if (user.experienceLevel == 0 && pointsToTransfer > pointsCurrentLevel) {
+            pointsToTransfer = pointsCurrentLevel;
+        }
 
         // Try to transfer the points to the tome and subtract the amount that
         // could be transferred from the player.
@@ -50,17 +56,16 @@ public class TomeOfMinorExperience extends BaseTomeOfExperience {
 
     @Override
     protected int transferToPlayer(ItemStack tomeItemStack, PlayerEntity user) {
-        int pointsTotal = user.totalExperience;
         int pointsToNextLevel = user.getNextLevelExperience();
         int pointsCurrentLevel = (int) Math.ceil(user.experienceProgress * (float)pointsToNextLevel);
-        int pointsNextLevel = pointsTotal - pointsCurrentLevel + pointsToNextLevel;
+        int pointsNextLevel = pointsToNextLevel - pointsCurrentLevel ;
 
         // Transfer a third of the points that the current level could hold.
         // If the transfer would cause the player to level up, just transfer enough
         // points to go up to the next level.
         int thirdOfCurrentLevel = (int) Math.ceil((float)pointsToNextLevel / 3f);
-        int pointsToTransfer = pointsTotal + thirdOfCurrentLevel > pointsNextLevel
-            ? pointsNextLevel - pointsTotal + 1
+        int pointsToTransfer = thirdOfCurrentLevel > pointsNextLevel
+            ? pointsNextLevel
             : thirdOfCurrentLevel;
 
         // Try to get the points from the tome - or as many as it can provide - and 

--- a/src/main/java/com/hangbunny/item/TomeOfSuperiorExperience.java
+++ b/src/main/java/com/hangbunny/item/TomeOfSuperiorExperience.java
@@ -38,7 +38,13 @@ public class TomeOfSuperiorExperience extends BaseTomeOfExperience {
             // Transfer all the points in the current level plus
             // a single point to go down to the previous level.
             int pointsToTransfer = pointsCurrentLevel + 1;
-            if (pointsToTransfer > user.totalExperience) { pointsToTransfer = user.totalExperience; }
+
+            // 'user.totalExperience' doesn't seem to report reliable values.
+            // Check that we're not transferring more points than the player has by
+            // checking both the level and the points in the current level.
+            if (user.experienceLevel == 0 && pointsToTransfer > pointsCurrentLevel) {
+                pointsToTransfer = pointsCurrentLevel;
+            }
 
             // Try to transfer the points to the tome and subtract the amount that
             // could be transferred from the player.


### PR DESCRIPTION

Fixes #35

The value of `totalExperience` in `PlayerEntity` doesn't seem to update when a player's experience points are manipulated via commands. Players would sometimes be unable to transfer experience points to tomes when their actual experience points and the value reported by `totalExperience` didn't match.

This removes uses of `totalExperience` to fix the transfer issues. All experience point transfer calculations now use only information from the player's current and next experience levels.

